### PR TITLE
fix: Run migrations as root

### DIFF
--- a/.github/workflows/ubuntu-2404-lamp-integration-test.yml
+++ b/.github/workflows/ubuntu-2404-lamp-integration-test.yml
@@ -99,7 +99,8 @@ jobs:
 
           # Install composer dependencies
           cd /var/www/horde
-          sudo composer install --no-dev --no-interaction --prefer-dist
+          sudo COMPOSER_ALLOW_SUPERUSER=1 composer config minimum-stability dev
+          sudo COMPOSER_ALLOW_SUPERUSER=1 composer install --no-interaction --prefer-dist
 
           # Set ownership for Apache
           sudo chown -R www-data:www-data /var/www/horde
@@ -195,7 +196,8 @@ jobs:
 
           sudo hordectl configure auth --driver=sql --encryption=ssha
 
-          sudo /var/www/horde/vendor/bin/horde-db-migrate up
+          cd /var/www/horde
+          sudo -u www-data vendor/bin/horde-db-migrate up
 
       - name: Configure admin secret for API
         run: |

--- a/.github/workflows/ubuntu-2404-lamp-integration-test.yml
+++ b/.github/workflows/ubuntu-2404-lamp-integration-test.yml
@@ -103,7 +103,13 @@ jobs:
 
           # Set ownership for Apache
           sudo chown -R www-data:www-data /var/www/horde
-          sudo chmod -R 755 /var/www/horde
+
+          # Set correct permissions: directories 755, files 644
+          sudo find /var/www/horde -type d -exec chmod 755 {} \;
+          sudo find /var/www/horde -type f -exec chmod 644 {} \;
+
+          # Make scripts executable
+          sudo chmod +x /var/www/horde/vendor/bin/*
 
           # Ensure var directories are writable
           sudo chmod -R 775 /var/www/horde/var
@@ -189,7 +195,7 @@ jobs:
 
           sudo hordectl configure auth --driver=sql --encryption=ssha
 
-          sudo -u www-data /var/www/horde/vendor/bin/horde-db-migrate up
+          sudo /var/www/horde/vendor/bin/horde-db-migrate up
 
       - name: Configure admin secret for API
         run: |


### PR DESCRIPTION
Minor tweaks to the LAMP workflow.
Add a LEPP equivalent (Ubuntu 24.04, PHP 8.4, Postgresql, Nginx)